### PR TITLE
dyn_kvp: introduce DYN_KVP_COMPARE_FUNCTION

### DIFF
--- a/dyn_kvp/README.md
+++ b/dyn_kvp/README.md
@@ -277,6 +277,9 @@ You can override that by defining:
 - a `DYN_KVP_HASH_FUNCTION` (i.e. `#define DYN_KVP_HASH_FUNCTION my_custom_hash`), which returns an `unsigned int` in the range `0..size` and takes as parameters:
   - a `size_t size` of how many slots exist in the hash (as passed to `_new`)
   - a `DYN_KVP_KEY_TYPE key` representing the key that the custom function should produce a hash for
+- a `DYN_KVP_COMPARE_FUNCTION` (default is `#define DYN_KVP_COMPARE_FUNCTION(a, b) ((a) == (b))`, you might want to use something like `#define DYN_KVP_COMPARE_FUNCTION(a, b) ((a)[0] == (b)[0] && !strcmp(a, b))` for a string key), which returns `1` if the two keys are equal, and `0` otherwise, and takes as parameters:
+  - a `DYN_KVP_KEY_TYPE a` representing the item key to compare
+  - a `DYN_KVP_KEY_TYPE b` representing the wanted item key to compare it to
 
 See `dyn_kvp/tests/charp_key` for an example of this.
 

--- a/dyn_kvp/dyn_kvp.h
+++ b/dyn_kvp/dyn_kvp.h
@@ -233,6 +233,10 @@ void DYN_KVP_F(DYN_KVP_TYPE_NAME, _clear)(struct DYN_KVP_TYPE_NAME *hash)
     hash->nkeys = 0;
 }
 
+#ifndef DYN_KVP_COMPARE_FUNCTION
+# define DYN_KVP_COMPARE_FUNCTION(x, y) ((x) == (y))
+#endif
+
 // Set a "key" to "val" in a KVP of this type.
 void DYN_KVP_F(DYN_KVP_TYPE_NAME, _set)(struct DYN_KVP_TYPE_NAME *hash, DYN_KVP_KEY_TYPE key, DYN_KVP_VALUE_TYPE *val)
 {
@@ -240,7 +244,7 @@ void DYN_KVP_F(DYN_KVP_TYPE_NAME, _set)(struct DYN_KVP_TYPE_NAME *hash, DYN_KVP_
         return;
     unsigned int hash_index = DYN_KVP_HASH_FUNCTION(hash->size, key);
     for (struct DYN_KVP_MEMBER_NAME *p = hash->hash[hash_index]; p; p = p->next)
-        if (p->key == key)
+        if (DYN_KVP_COMPARE_FUNCTION(p->key, key))
         {
             p->value = val;
             return;
@@ -327,7 +331,7 @@ int DYN_KVP_F(DYN_KVP_TYPE_NAME, _exists)(struct DYN_KVP_TYPE_NAME *hash, DYN_KV
         return 0;
     unsigned int hash_index = DYN_KVP_HASH_FUNCTION(hash->size, key);
     for (struct DYN_KVP_MEMBER_NAME *p = hash->hash[hash_index]; p; p = p->next)
-        if (p->key == key)
+        if (DYN_KVP_COMPARE_FUNCTION(p->key, key))
             return 1;
     return 0;
 }
@@ -341,7 +345,7 @@ void DYN_KVP_F(DYN_KVP_TYPE_NAME, _del)(struct DYN_KVP_TYPE_NAME *hash, DYN_KVP_
     struct DYN_KVP_MEMBER_NAME *prev = NULL;
     for (struct DYN_KVP_MEMBER_NAME *p = hash->hash[hash_index]; p; p = p->next)
     {
-        if (p->key == key)
+        if (DYN_KVP_COMPARE_FUNCTION(p->key, key))
         {
             if (prev)
                 prev->next = p->next;
@@ -363,7 +367,7 @@ DYN_KVP_VALUE_TYPE *DYN_KVP_F(DYN_KVP_TYPE_NAME, _get)(struct DYN_KVP_TYPE_NAME 
         return NULL;
     unsigned int hash_index = DYN_KVP_HASH_FUNCTION(hash->size, key);
     for (struct DYN_KVP_MEMBER_NAME *p = hash->hash[hash_index]; p; p = p->next)
-        if (p->key == key)
+        if (DYN_KVP_COMPARE_FUNCTION(p->key, key))
             return p->value;
     return NULL;
 }

--- a/dyn_kvp/tests/charp_key/charp_key.c
+++ b/dyn_kvp/tests/charp_key/charp_key.c
@@ -32,6 +32,8 @@ size_t custom_foo_hash(size_t size, const char *key)
 #define DYN_KVP_KEY_TYPE const char *
 #define DYN_KVP_HASH_FUNCTION custom_foo_hash
 #define DYN_KVP_IMPLEMENTATION
+#define DYN_KVP_COMPARE_FUNCTION(a, b) ((a[0] == b[0]) && !strcmp(a, b))
+#include <string.h> // strcmp
 #include "../../dyn_kvp.h"
 #undef DYN_KVP_IMPLEMENTATION
 #undef DYN_KVP_HASH_FUNCTION
@@ -56,6 +58,12 @@ void test_charp_foo(void)
         struct custom_foo *c1 = custom_foo_new(1, 2);
         cfoo_kvp_set(hash, "foo", c1);
         tap_is_int(cfoo_kvp_nkeys(hash), 1, "cfoo_kvp_nkeys() returns 1 after cfoo_kvp_set()");
+        char foo1[4];
+        foo1[0] = 'f';
+        foo1[1] = 'o';
+        foo1[2] = 'o';
+        foo1[3] = '\0';
+        tap_is_int(cfoo_kvp_exists(hash, foo1), 1, "cfoo_kvp_exists(foo) returns 1 after cfoo_kvp_set()");
         tap_is_int(cfoo_kvp_exists(hash, "foo"), 1, "cfoo_kvp_exists(foo) returns 1 after cfoo_kvp_set()");
         tap_is_int(cfoo_kvp_exists(hash, "bar"), 0, "cfoo_kvp_exists(bar) returns 0 after cfoo_kvp_set()");
         tap_is_voidp(cfoo_kvp_get(hash, "foo"), c1, "cfoo_kvp_get(foo) returns c1 after cfoo_kvp_set()");


### PR DESCRIPTION
... and "properly fix" the char pointer example, so that it doesn't rely on pointer equality for comparisons.

The DYN_KVP_COMPARE_FUNCTION allows a caller to customize how the comparison should be performed, and defaults to the previous `==`.

Added a previously failing test, whereby the "foo" key being sought is created byte by byte, which won't match when compared with `==`.